### PR TITLE
Store only one handle; restore by title if !=1 match

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/User32.cs
+++ b/User32.cs
@@ -66,9 +66,8 @@ namespace WindowSnapshotter
         public struct WindowDetails
         {
             public string WindowTitle;
-            public Int32 WindowHandle32;
-            public Int64 WindowHandle64;
-            public WINDOWPLACEMENT Windowplacement;
+            public long WindowHandle;
+            public WINDOWPLACEMENT WindowPlacement;
         }
 
         public enum showCmdFlags


### PR DESCRIPTION
No need for separate properties for Int32 and Int64 handles as they both fit in a long (Int64).

If there's not exactly one match for a window by handle, match by title instead.